### PR TITLE
fix: errors from GetInt when text is not numeric

### DIFF
--- a/lua/pixelui/elements/cl_text_entry_internal.lua
+++ b/lua/pixelui/elements/cl_text_entry_internal.lua
@@ -282,7 +282,10 @@ function PANEL:GetAutoComplete(txt)
 end
 
 function PANEL:GetInt()
-    return math.floor(tonumber(self:GetText()) + 0.5)
+    local num = tonumber(self:GetText())
+    if not num then return end
+
+    return math.floor(num + 0.5)
 end
 
 function PANEL:GetFloat()


### PR DESCRIPTION
As a result of the discussion in the latest commit (dde3008), it turns out this should actually be the expect behaviour, [according to the GMod wiki](https://wiki.facepunch.com/gmod/DTextEntry:GetInt) at least.

This shouldn't have any negative effects on existing uses of the library - let me know via an issue if this does somehow break something.

[I've also made a PR on the gmod repo to fix the bug there too.](https://github.com/Facepunch/garrysmod/pull/1808)