### PR TITLE
feat: add misc helper functions to the color metatable

### DIFF
--- a/lua/pixelui/core/cl_color.lua
+++ b/lua/pixelui/core/cl_color.lua
@@ -151,9 +151,10 @@ function colorMeta:Lerp(t, to)
     return self
 end
 
+local colorToHSL = PIXEL.ColorToHSL
 function colorMeta:IsLight()
-    local _, _, light = PIXEL.ColorToHSL(self)
-    return light >= .5
+    local _, _, lightness = colorToHSL(self)
+    return lightness >= .5
 end
 
 function colorMeta:EqualTo(to)

--- a/lua/pixelui/core/cl_color.lua
+++ b/lua/pixelui/core/cl_color.lua
@@ -141,6 +141,6 @@ function colorMeta:Lerp(amt, to)
     return PIXEL.LerpColor(amt, self, to)
 end
 
-function colorMeta:__eq(to)
+function colorMeta:EqualTo(to)
     return self.r == to.r and self.g == to.g and self.b == to.b and self.a == to.a
 end

--- a/lua/pixelui/core/cl_color.lua
+++ b/lua/pixelui/core/cl_color.lua
@@ -131,3 +131,21 @@ function PIXEL.GetRainbowColor()
 
     return lastCol
 end
+
+local colorMeta = FindMetaTable("Color")
+
+function colorMeta:Copy()
+    return PIXEL.CopyColor(self)
+end
+
+function colorMeta:Offset(off)
+    return PIXEL.OffsetColor(self, off)
+end
+
+function colorMeta:Lerp(amt, to)
+    return PIXEL.LerpColor(amt, self, to)
+end
+
+function colorMeta:__eq(to)
+    return self.r == to.r and self.g == to.g and self.b == to.b and self.a == to.a
+end

--- a/lua/pixelui/core/cl_color.lua
+++ b/lua/pixelui/core/cl_color.lua
@@ -151,6 +151,11 @@ function colorMeta:Lerp(t, to)
     return self
 end
 
+function colorMeta:IsLight()
+    local _, _, light = PIXEL.ColorToHSL(self)
+    return light >= .5
+end
+
 function colorMeta:EqualTo(to)
     return self.r == to.r and self.g == to.g and self.b == to.b and self.a == to.a
 end

--- a/lua/pixelui/core/cl_color.lua
+++ b/lua/pixelui/core/cl_color.lua
@@ -134,13 +134,8 @@ end
 
 local colorMeta = FindMetaTable("Color")
 
-function colorMeta:Copy()
-    return PIXEL.CopyColor(self)
-end
-
-function colorMeta:Offset(off)
-    return PIXEL.OffsetColor(self, off)
-end
+colorMeta.Copy = PIXEL.CopyColor
+colorMeta.Offset = PIXEL.OffsetColor
 
 function colorMeta:Lerp(amt, to)
     return PIXEL.LerpColor(amt, self, to)

--- a/lua/pixelui/core/cl_color.lua
+++ b/lua/pixelui/core/cl_color.lua
@@ -135,10 +135,20 @@ end
 local colorMeta = FindMetaTable("Color")
 
 colorMeta.Copy = PIXEL.CopyColor
-colorMeta.Offset = PIXEL.OffsetColor
 
-function colorMeta:Lerp(amt, to)
-    return PIXEL.LerpColor(amt, self, to)
+function colorMeta:Offset(offset)
+    self.r = self.r + offset
+    self.g = self.g + offset
+    self.b = self.b + offset
+    return self
+end
+
+function colorMeta:Lerp(t, to)
+    self.r = lerp(t, self.r, to.r)
+    self.g = lerp(t, self.g, to.g)
+    self.b = lerp(t, self.b, to.b)
+    self.a = lerp(t, self.a, to.a)
+    return self
 end
 
 function colorMeta:EqualTo(to)


### PR DESCRIPTION
Add Copy, Offset, Lerp, and __eq methods to the Color metatable to make working with colors a bit more easy