### PR TITLE
refactor: global loader methods, improve readability

### DIFF
--- a/lua/autorun/sh_pixelui_loader.lua
+++ b/lua/autorun/sh_pixelui_loader.lua
@@ -20,22 +20,22 @@ PIXEL = PIXEL or {}
 PIXEL.UI = PIXEL.UI or {}
 PIXEL.UI.Version = "1.1.0"
 
-function PIXEL.LoadDirectory(directory)
-	local files, folders = file.Find(directory .. "/*", "LUA")
+function PIXEL.LoadDirectory(path)
+	local files, folders = file.Find(path .. "/*", "LUA")
 
 	for _, fileName in ipairs(files) do
-		directory = directory .. "/" .. fileName
+		path = path .. "/" .. fileName
 
 		if CLIENT then
-			include(directory)
+			include(path)
 		else
 			if fileName:StartWith("cl_") then
-				AddCSLuaFile(directory)
+				AddCSLuaFile(path)
 			elseif fileName:StartWith("sh_") then
-				AddCSLuaFile(directory)
-				include(directory)
+				AddCSLuaFile(path)
+				include(path)
 			else
-				include(directory)
+				include(path)
 			end
 		end
 	end
@@ -43,10 +43,10 @@ function PIXEL.LoadDirectory(directory)
 	return files, folders
 end
 
-function PIXEL.LoadDirectoryRecursive(baseDirectory)
-	local _, folders = PIXEL.LoadDirectory(baseDirectory)
+function PIXEL.LoadDirectoryRecursive(basePath)
+	local _, folders = PIXEL.LoadDirectory(basePath)
 	for _, folderName in ipairs(folders) do
-		PIXEL.LoadDirectoryRecursive(baseDirectory .. "/" .. folderName)
+		PIXEL.LoadDirectoryRecursive(basePath .. "/" .. folderName)
 	end
 end
 

--- a/lua/autorun/sh_pixelui_loader.lua
+++ b/lua/autorun/sh_pixelui_loader.lua
@@ -20,29 +20,37 @@ PIXEL = PIXEL or {}
 PIXEL.UI = PIXEL.UI or {}
 PIXEL.UI.Version = "1.1.0"
 
-local function loadDirectory(dir)
-	local fil, fol = file.Find(dir .. "/*", "LUA")
+function PIXEL.LoadDirectory(directory)
+	local files, folders = file.Find(directory .. "/*", "LUA")
 
-	for k,v in ipairs(fil) do
-		local dirs = dir .. "/" .. v
+	for _, fileName in ipairs(files) do
+		directory = directory .. "/" .. fileName
 
-		if v:StartWith("cl_") then
-			if SERVER then AddCSLuaFile(dirs)
-			else include(dirs) end
-		elseif v:StartWith("sh_") then
-			AddCSLuaFile(dirs)
-			include(dirs)
+		if CLIENT then
+			include(directory)
 		else
-			if SERVER then include(dirs) end
+			if fileName:StartWith("cl_") then
+				AddCSLuaFile(directory)
+			elseif fileName:StartWith("sh_") then
+				AddCSLuaFile(directory)
+				include(directory)
+			else
+				include(directory)
+			end
 		end
 	end
 
-	for k,v in pairs(fol) do
-		loadDirectory(dir .. "/" .. v)
+	return files, folders
+end
+
+function PIXEL.LoadDirectoryRecursive(baseDirectory)
+	local _, folders = PIXEL.LoadDirectory(baseDirectory)
+	for _, folderName in ipairs(folders) do
+		PIXEL.LoadDirectoryRecursive(baseDirectory .. "/" .. folderName)
 	end
 end
 
-loadDirectory("pixelui")
+PIXEL.LoadDirectoryRecursive("pixelui")
 
 hook.Run("PIXEL.UI.FullyLoaded")
 


### PR DESCRIPTION
Separates out the load directory method into two, one that loads a directory, and one that adds recursive loading.

These methods were also refactored to improve readability, and made global so they can be used elsewhere.