### PR TITLE
Add layout invalidation to category panel init

### DIFF
--- a/lua/pixelui/elements/cl_category.lua
+++ b/lua/pixelui/elements/cl_category.lua
@@ -65,6 +65,8 @@ function PANEL:Init()
     self.SlideAnimation = Derma_Anim("Anim", self, self.AnimSlide)
 
     self.BackgroundCol = PIXEL.OffsetColor(PIXEL.Colors.Background, 2)
+
+    self:InvalidateLayout(true)
 end
 
 function PANEL:UnselectAll()


### PR DESCRIPTION
This fixes a bug that makes it so when the category is supposed to start unfolded/expanded, it will not be properly render just after being created, only after being folder and unfolded again