### PR TITLE
90° Arc Offset

### DIFF
--- a/lua/pixelui/libraries/cl_arc.lua
+++ b/lua/pixelui/libraries/cl_arc.lua
@@ -31,7 +31,7 @@ function PIXEL.PrecacheArc(cx, cy, radius, thickness, startang, endang, roughnes
     for deg = startang, endang, step do
         local rad = math.rad(deg)
         -- local rad = deg2rad * deg
-        local ox, oy = cx + (math.cos(rad + arcOffset) * r), cy + (-math.sin(rad * arcOffset) * r)
+        local ox, oy = cx + (math.cos(rad + arcOffset) * r), cy + (-math.sin(rad + arcOffset) * r)
 
         table.insert(inner, {
             x = ox,
@@ -47,7 +47,7 @@ function PIXEL.PrecacheArc(cx, cy, radius, thickness, startang, endang, roughnes
     for deg = startang, endang, step do
         local rad = math.rad(deg)
         -- local rad = deg2rad * deg
-        local ox, oy = cx + (math.cos(rad * arcOffset) * radius), cy + (-math.sin(rad * arcOffset) * radius)
+        local ox, oy = cx + (math.cos(rad + arcOffset) * radius), cy + (-math.sin(rad + arcOffset) * radius)
 
         table.insert(outer, {
             x = ox,

--- a/lua/pixelui/libraries/cl_arc.lua
+++ b/lua/pixelui/libraries/cl_arc.lua
@@ -10,6 +10,7 @@ function PIXEL.DrawUncachedArc(cx, cy, radius, thickness, startang, endang, roug
     PIXEL.DrawArc(PIXEL.PrecacheArc(cx, cy, radius, thickness, startang, endang, roughness))
 end
 
+local arcOffset = math.rad(90)
 function PIXEL.PrecacheArc(cx, cy, radius, thickness, startang, endang, roughness)
     local triarc = {}
     -- local deg2rad = math.pi / 180
@@ -30,7 +31,7 @@ function PIXEL.PrecacheArc(cx, cy, radius, thickness, startang, endang, roughnes
     for deg = startang, endang, step do
         local rad = math.rad(deg)
         -- local rad = deg2rad * deg
-        local ox, oy = cx + (math.cos(rad) * r), cy + (-math.sin(rad) * r)
+        local ox, oy = cx + (math.cos(rad + arcOffset) * r), cy + (-math.sin(rad * arcOffset) * r)
 
         table.insert(inner, {
             x = ox,
@@ -46,7 +47,7 @@ function PIXEL.PrecacheArc(cx, cy, radius, thickness, startang, endang, roughnes
     for deg = startang, endang, step do
         local rad = math.rad(deg)
         -- local rad = deg2rad * deg
-        local ox, oy = cx + (math.cos(rad) * radius), cy + (-math.sin(rad) * radius)
+        local ox, oy = cx + (math.cos(rad * arcOffset) * radius), cy + (-math.sin(rad * arcOffset) * radius)
 
         table.insert(outer, {
             x = ox,


### PR DESCRIPTION
To fix it beeing weird in some (literally) edge cases, 0° should be at the top.

For some weird reason it only works in this way


It could also be that `startang` is doing something weird in this case, but for now this fixes it i guess?

Without this offset, but startang of 90:
https://files.justplayer.de/justin/43a712f01af5b9d93f23816512b612eabdc95c6e.mp4

Without offset and default startang:
https://files.justplayer.de/justin/e0fcc7163ceafe0b1774d26164862c7d98ecb336.mp4

With this offset and default startang:
https://files.justplayer.de/justin/1495e484337df7c1fdcee72611336602475fe24a.mp4