### PR TITLE
fix: 404 and similar results would be written to cache

### DIFF
--- a/lua/pixelui/core/cl_images.lua
+++ b/lua/pixelui/core/cl_images.lua
@@ -38,7 +38,7 @@ local function processQueue()
 
         http.Fetch((useProxy and ("https://proxy.duckduckgo.com/iu/?u=" .. url)) or url,
             function(body, len, headers, code)
-                if len > 2097152 then
+                if len > 2097152 or code ~= 200 then
                     materials[filePath] = Material("nil")
                 else
                     local writeFilePath = filePath


### PR DESCRIPTION
This change will prevent any non-"OK" (http 200) responses from being written to the file cache.