### PR TITLE
fix: use official color:lerp implementation if possible

### DIFF
--- a/lua/pixelui/core/cl_color.lua
+++ b/lua/pixelui/core/cl_color.lua
@@ -142,7 +142,7 @@ do
 end
 
 function PIXEL.LerpColor(t, from, to)
-    return createColor(from.r, from.g, from.b, from.a):Lerp(t, to)
+    return createColor(from.r, from.g, from.b, from.a):Lerp(to, t)
 end
 
 function PIXEL.IsColorEqualTo(from, to)
@@ -161,11 +161,3 @@ function colorMeta:Offset(offset)
     return self
 end
 
-local lerp = Lerp
-function colorMeta:Lerp(t, to)
-    self.r = lerp(t, self.r, to.r)
-    self.g = lerp(t, self.g, to.g)
-    self.b = lerp(t, self.b, to.b)
-    self.a = lerp(t, self.a, to.a)
-    return self
-end

--- a/lua/pixelui/core/cl_color.lua
+++ b/lua/pixelui/core/cl_color.lua
@@ -161,3 +161,25 @@ function colorMeta:Offset(offset)
     return self
 end
 
+-- Combatibility for versions before 2024.06.28
+if not colorMeta.Lerp then
+    local lerp = Lerp
+    local isColor = IsColor
+    function colorMeta:Lerp(target, fraction)
+        if isColor(fraction) then
+            -- Don't break addons using this based on Pixel UI for now.
+            local rememberFraction = fraction
+            fraction = target
+            target = rememberFraction
+
+            -- Scream at them though, should be fine to keep this backwards compatibility until the update. 
+            ErrorNoHaltWithStack("Deprecated PIXEL-UI Color:Lerp(fraction, target) is used.")
+        end
+
+        self.r = lerp(fraction, self.r, target.r)
+        self.g = lerp(fraction, self.g, target.g)
+        self.b = lerp(fraction, self.b, target.b)
+        self.a = lerp(fraction, self.a, target.a)
+        return self
+    end
+end

--- a/lua/pixelui/core/cl_color.lua
+++ b/lua/pixelui/core/cl_color.lua
@@ -165,6 +165,7 @@ end
 if not colorMeta.Lerp then
     local lerp = Lerp
     local isColor = IsColor
+    local deprecation_warning_shown = false
     function colorMeta:Lerp(target, fraction)
         if isColor(fraction) then
             -- Don't break addons using this based on Pixel UI for now.
@@ -172,8 +173,11 @@ if not colorMeta.Lerp then
             fraction = target
             target = rememberFraction
 
-            -- Scream at them though, should be fine to keep this backwards compatibility until the update. 
-            ErrorNoHaltWithStack("Deprecated PIXEL-UI Color:Lerp(fraction, target) is used.")
+            if not deprecation_warning_shown then
+                deprecation_warning_shown = true
+                -- Scream at them at least once though, should be fine to keep this backwards compatibility until the update. 
+                ErrorNoHaltWithStack("Deprecated PIXEL-UI Color:Lerp(fraction, target) is used.")
+            end
         end
 
         self.r = lerp(fraction, self.r, target.r)


### PR DESCRIPTION
With garrysmod version 2024.06.28 there is a new official colorObj:Lerp() method which is not directly compatible with pixel's definition as the parameters are swapped causing issues.
Wiki Page: https://wiki.facepunch.com/gmod/Color:Lerp

The new Lerp method does not seem to be on default branch right now, for this case I have left the old pixel ui implementation as a replacement with the parameters swapped but with backwards compatibility and deprecation warning until the new implementation gets merged to garrysmod main.

Addons using the original pixel ui implementation may break with this change after the garrysmod update.